### PR TITLE
feat: Auto-generate old-style schema files for contract msgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to the "cosmy-wasmy" extension will be documented in this fi
 - Added support for `SigningCosmWasmClient.executeMultiple` in API
 - Can now send funds while executing a contract and while initializing a contract 💰
 - Added `Clear History` button and `Export History as JSON` button to CosmWasm history view
+- Auto-generate old-style contract schema when `cargo schema` is run
 
 ### Changed
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,8 @@ import { Contract } from './models/contract';
 import { Commands } from './commands/command';
 import { Utils, Views } from './views/utils';
 import { Workspace } from './helpers/workspace';
+import { TextEncoder } from 'util';
+import { FileWatcher } from './helpers/fileWatcher';
 
 
 // this method is called when your extension is activated
@@ -18,6 +20,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 	Commands.Register(context);
 	Views.Register(context);
+	FileWatcher.Register();
 
 	const rustLangExtension = vscode.extensions.getExtension('rust-lang.rust-analyzer');
 	if (!rustLangExtension) {
@@ -30,4 +33,5 @@ export async function activate(context: vscode.ExtensionContext) {
 
 // this method is called when your extension is deactivated
 export function deactivate() {
+	global.schemaFileWatch.dispose();
 }

--- a/src/helpers/fileWatcher.ts
+++ b/src/helpers/fileWatcher.ts
@@ -3,8 +3,9 @@ import * as vscode from 'vscode';
 var toml = require('toml');
 
 export class FileWatcher {
-    public static Register() {
-        const schemaFile = "schema/counter.json";
+    public static async Register() {
+        const contractName = await getContractName();
+        const schemaFile = "schema/" + contractName + ".json";
         const pattern = new vscode.RelativePattern(vscode.workspace.workspaceFolders[0], schemaFile);
         global.schemaFileWatch = vscode.workspace.createFileSystemWatcher(pattern, false, false, true);
         global.schemaFileWatch.onDidChange(() => {
@@ -31,14 +32,6 @@ export class FileWatcher {
                 }
                 if (schema.sudo) {
                     generateSudoSchema(schema);
-                }
-
-                async function getContractName() {
-                    const cargoToml = vscode.Uri.joinPath(vscode.workspace.workspaceFolders[0].uri, "Cargo.toml");
-                    const doc = await vscode.workspace.openTextDocument(cargoToml);
-                    const cargo = toml.parse(doc.getText());
-                    const contractName = cargo.package.name;
-                    return contractName;
                 }
 
                 function generateInstantiateSchema(schema: any) {
@@ -72,4 +65,12 @@ export class FileWatcher {
             }, 6000);
         }
     }
+}
+
+async function getContractName() {
+    const cargoToml = vscode.Uri.joinPath(vscode.workspace.workspaceFolders[0].uri, "Cargo.toml");
+    const doc = await vscode.workspace.openTextDocument(cargoToml);
+    const cargo = toml.parse(doc.getText());
+    const contractName = cargo.package.name;
+    return contractName;
 }

--- a/src/helpers/fileWatcher.ts
+++ b/src/helpers/fileWatcher.ts
@@ -1,0 +1,66 @@
+import { TextEncoder } from 'util';
+import * as vscode from 'vscode';
+
+export class FileWatcher {
+    public static Register() {
+        const schemaFile = "schema/counter.json";
+        const pattern = new vscode.RelativePattern(vscode.workspace.workspaceFolders[0], schemaFile);
+        global.schemaFileWatch = vscode.workspace.createFileSystemWatcher(pattern, false, false, true);
+        global.schemaFileWatch.onDidChange(() => {
+            vscode.window.showInformationMessage("change")
+            generateSchemaFiles();
+        });
+        global.schemaFileWatch.onDidCreate(() => {
+            vscode.window.showInformationMessage("create")
+        });
+
+        function generateSchemaFiles() {
+            // executing after 6 secs cuz when event is hit, the file contents are still old 👎🏻
+            // normal text change and save works fine, but the cargo schema updating the contract.json seems to not show updated file
+            setTimeout(async function () {
+                const schemaUri = vscode.Uri.joinPath(vscode.workspace.workspaceFolders[0].uri, "schema", "counter.json")
+                const doc = await vscode.workspace.openTextDocument(schemaUri);
+                const schema = JSON.parse(doc.getText());
+
+                generateInstantiateSchema(schema);
+                generateQuerySchema(schema);
+                generateExecuteSchema(schema);
+                if (schema.migrate) {
+                    generateMigrateSchema(schema);
+                }
+                if (schema.sudo) {
+                    generateSudoSchema(schema);
+                }
+
+                function generateInstantiateSchema(schema: any) {
+                    const instantiateSchemaFile = vscode.Uri.joinPath(vscode.workspace.workspaceFolders[0].uri, "schema", "instantiate_msg.json");
+                    saveSchemaFile(schema.instantiate, instantiateSchemaFile);
+                }
+
+                function generateQuerySchema(schema: any) {
+                    const querySchemaFile = vscode.Uri.joinPath(vscode.workspace.workspaceFolders[0].uri, "schema", "query_msg.json");
+                    saveSchemaFile(schema.query, querySchemaFile);
+                }
+
+                function generateExecuteSchema(schema: any) {
+                    const executeSchemaFile = vscode.Uri.joinPath(vscode.workspace.workspaceFolders[0].uri, "schema", "execute_msg.json");
+                    saveSchemaFile(schema.execute, executeSchemaFile);
+                }
+
+                function generateMigrateSchema(schema: any) {
+                    const executeMigrateFile = vscode.Uri.joinPath(vscode.workspace.workspaceFolders[0].uri, "schema", "migrate_msg.json");
+                    saveSchemaFile(schema.migrate, executeMigrateFile);
+                }
+
+                function generateSudoSchema(schema: any) {
+                    const sudoSchemaFile = vscode.Uri.joinPath(vscode.workspace.workspaceFolders[0].uri, "schema", "sudo_msg.json");
+                    saveSchemaFile(schema.sudo, sudoSchemaFile);
+                }
+
+                function saveSchemaFile(schema: any, schemaFile: vscode.Uri) {
+                    vscode.workspace.fs.writeFile(schemaFile, new TextEncoder().encode(JSON.stringify(schema)));
+                }
+            }, 6000);
+        }
+    }
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-var */
 
+import * as vscode from 'vscode';
 import { ChainConfig } from "./helpers/workspace";
 import { AccountDataProvider } from "./views/accountDataProvider";
 import { ContractDataProvider } from "./views/contractDataProvider";
@@ -8,6 +9,7 @@ declare global {
   var accountViewProvider: AccountDataProvider;
   var contractViewProvider: ContractDataProvider;
   var workspaceChain: ChainConfig;
+  var schemaFileWatch: vscode.FileSystemWatcher;
 }
 
 export { };


### PR DESCRIPTION
`cargo schema` now generates contract.json instead of instantiate_msg.json, query_msg.json etc.
This generates those files whenever contract.json is generated by attaching a file watcher