### PR TITLE
feat: Beaker integration part 2 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,9 @@ All notable changes to the "cosmy-wasmy" extension will be documented in this fi
 - Added `Clear History` button and `Export History as JSON` button to CosmWasm history view
 - Auto-generate old-style contract schema when `cargo schema` is run
 - Load a wasm binary in a CosmWasm VM. Supports instantiate, query and execute. Uses `@terran-one/cw-simulate`. Absolute GOATS those peeps 🎉
-- [Beaker](https://github.com/osmosis-labs/beaker) integration - autosync accounts and chain configs if Beaker.toml is found in the repository. Configured in the setting `beaker.autosync`
+- [Beaker](https://github.com/osmosis-labs/beaker) integration 
+    - autosync accounts and chain configs if Beaker.toml is found in the repository. Configured in the setting `beaker.autosync`
+    - right click on `Beaker.toml` allows to manually sync the accounts and chain configs from the selected file 
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -184,6 +184,11 @@
         "title": "Execute Tx",
         "category": "Cosmy Wasmy",
         "enablement": "resourceLangId == json"
+      },
+      {
+        "command": "cosmy-wasmy.beakerTomlSync",
+        "title": "Sync Beaker config",
+        "category": "Cosmy Wasmy"
       }
     ],
     "configuration": [
@@ -439,6 +444,10 @@
         {
           "command": "cosmy-wasmy.wasmInteract",
           "when": "resourceExtname == .wasm"
+        },
+        {
+          "command": "cosmy-wasmy.beakerTomlSync",
+          "when": "resourceFilename == Beaker.toml"
         }
       ],
       "editor/context": [

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -23,6 +23,7 @@ export class Commands {
 		CosmwasmCmds.Register(context);
 
 		this.registerReloadConfigCmd(context, accountViewProvider, contractViewProvider);	
+		this.syncBeakerTomlCmd(context);
 		//this.registerRecordCWCmd(context);		
 	}
 
@@ -109,6 +110,16 @@ export class Commands {
 		let disposable = vscode.commands.registerCommand('cosmy-wasmy.recordCW', () => {
 			Workspace.ToggleRecordCW();
 			Utils.ShowRecordStatusItem();
+		});
+		context.subscriptions.push(disposable);
+	}
+
+	private static syncBeakerTomlCmd(context: vscode.ExtensionContext) {
+		let disposable = vscode.commands.registerCommand('cosmy-wasmy.beakerTomlSync', async (item: vscode.Uri) => {
+			if (item) {
+				await Utils.BeakerSync(item, context);
+				vscode.window.showInformationMessage("Finished syncing accounts and chains from Beaker.toml")
+			}
 		});
 		context.subscriptions.push(disposable);
 	}

--- a/src/views/utils.ts
+++ b/src/views/utils.ts
@@ -69,13 +69,17 @@ export class Utils {
             const beakerFile = files.filter(f => f[0].toLowerCase() === "beaker.toml");
             if (beakerFile && beakerFile.length == 1) {
                 const beakerFilePath = vscode.Uri.joinPath(vscode.workspace.workspaceFolders[0].uri, "Beaker.toml");
-                const fileBuf = await vscode.workspace.fs.readFile(beakerFilePath);
-                const content = toml.parse(new TextDecoder().decode(fileBuf));
-
-                Utils.syncAccounts(content, context);
-                Utils.syncChains(content);
+                await Utils.BeakerSync(beakerFilePath, context);
             }
         }
+    }
+
+    public static async BeakerSync(beakerFilePath: vscode.Uri, context: vscode.ExtensionContext) {
+        const fileBuf = await vscode.workspace.fs.readFile(beakerFilePath);
+        const content = toml.parse(new TextDecoder().decode(fileBuf));
+
+        Utils.syncAccounts(content, context);
+        Utils.syncChains(content);
     }
 
     private static syncChains(content: any) {


### PR DESCRIPTION
- Right click on `Beaker.toml` shows option to manually sync accounts and chain config