### PR TITLE
fix: fixed missing webpack export of `bufferutil` and `utf-8-validate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable changes to the Cosmy Wasmy extension will be documented in this file
 
 - Updated Archway constantine-1 to constantine-2 configuration in present chain config
 
+### Fixed
+
+- Fixed missing webpack export of `bufferutil` and `utf-8-validate`
+
 ## [v2.0.0] - 24 March 2023
 
 Wohoooo!! 🎉

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cosmy-wasmy",
-  "version": "1.2.1",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cosmy-wasmy",
-      "version": "1.2.1",
+      "version": "2.1.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@cosmjs/amino": "^0.29.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,8 @@ const extensionConfig = {
     libraryTarget: 'commonjs2'
   },
   externals: {
+    bufferutil: "bufferutil",
+    "utf-8-validate": "utf-8-validate",
     vscode: 'commonjs vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
     // modules added here also need to be added in the .vscodeignore file
   },


### PR DESCRIPTION
Ref: https://github.com/spoo-bar/cosmy-wasmy/issues/49