### PR TITLE
revert: removing webpack export of bufferutil and utf-8-validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ All notable changes to the Cosmy Wasmy extension will be documented in this file
 ### Security 
 -->
 
+## [Unreleased]
+
+### Fixed
+
+- Closes [#59](https://github.com/spoo-bar/cosmy-wasmy/issues/59) which prevented the extension loading on mac due to webpack export [#51](https://github.com/spoo-bar/cosmy-wasmy/pull/51)
+
+
 ## [v2.2.0] - 11 April 2023
 
 > **Note**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,8 +20,6 @@ const extensionConfig = {
     libraryTarget: 'commonjs2'
   },
   externals: {
-    bufferutil: "bufferutil",
-    "utf-8-validate": "utf-8-validate",
     vscode: 'commonjs vscode' // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
     // modules added here also need to be added in the .vscodeignore file
   },


### PR DESCRIPTION
Ref: https://github.com/spoo-bar/cosmy-wasmy/issues/59