### PR TITLE
feat: add `CoinType` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to the Cosmy Wasmy extension will be documented in this file
 
 - For localnet chains, all contracts on the chain can be imported in single click.
 - Support [Finschia testnet](https://www.finschia.io/) - Finschia aims to become the world’s No. 1 blockchain ecosystem, leading the popularization of Web3 and securing over 1 billion users. Added configurations for localnet as well as testnet chains
+- Support `coinType` - Can use it when generate account, default `118`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ The structure of the expected setting for `cosmywasamy.chains`:
         "chainGasDenom": "uosmo", // The micro denom used to pay for gas
         "chainDenomDecimals": "6", // Default decimals to display account balance
         "signType": "tmsecp256k1", // Which signing scheme to use? tmsecp256k1 or ethsecp256k1
+        "coinType": "118", // Coin type registered for the chain
         "chainDenom": "uosmo", // the micro denom used to track account balance
         "faucetEndpoint": "http://localhost:8000", //Faucet address and port to request funds
         "accountExplorerLink": "https://testnet.mintscan.io/osmosis-testnet/account/${accountAddress}", //Block explorer url which includes '${accountAddress}' text to generate account url

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@cosmjs/amino": "^0.28.4",
         "@cosmjs/cosmwasm-stargate": "^0.28.4",
+        "@cosmjs/crypto": "^0.31.0",
         "@cosmjs/faucet-client": "^0.28.4",
         "@cosmjs/launchpad": "^0.27.1",
         "@cosmjs/math": "^0.30.1",
@@ -653,6 +654,20 @@
         "@cosmjs/utils": "0.28.13"
       }
     },
+    "node_modules/@cosmjs/amino/node_modules/@cosmjs/crypto": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.28.13.tgz",
+      "integrity": "sha512-ynKfM0q/tMBQMHJby6ad8lR3gkgBKaelQhIsCZTjClsnuC7oYT9y3ThSZCUWr7Pa9h0J8ahU2YV2oFWFVWJQzQ==",
+      "dependencies": {
+        "@cosmjs/encoding": "0.28.13",
+        "@cosmjs/math": "0.28.13",
+        "@cosmjs/utils": "0.28.13",
+        "@noble/hashes": "^1",
+        "bn.js": "^5.2.0",
+        "elliptic": "^6.5.3",
+        "libsodium-wrappers": "^0.7.6"
+      }
+    },
     "node_modules/@cosmjs/amino/node_modules/@cosmjs/math": {
       "version": "0.28.13",
       "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.28.13.tgz",
@@ -679,15 +694,7 @@
         "pako": "^2.0.2"
       }
     },
-    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/math": {
-      "version": "0.28.13",
-      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.28.13.tgz",
-      "integrity": "sha512-PDpL8W/kbyeWi0mQ2OruyqE8ZUAdxPs1xCbDX3WXJwy2oU+X2UTbkuweJHVpS9CIqmZulBoWQAmlf6t6zr1N/g==",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      }
-    },
-    "node_modules/@cosmjs/crypto": {
+    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/crypto": {
       "version": "0.28.13",
       "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.28.13.tgz",
       "integrity": "sha512-ynKfM0q/tMBQMHJby6ad8lR3gkgBKaelQhIsCZTjClsnuC7oYT9y3ThSZCUWr7Pa9h0J8ahU2YV2oFWFVWJQzQ==",
@@ -701,13 +708,50 @@
         "libsodium-wrappers": "^0.7.6"
       }
     },
-    "node_modules/@cosmjs/crypto/node_modules/@cosmjs/math": {
+    "node_modules/@cosmjs/cosmwasm-stargate/node_modules/@cosmjs/math": {
       "version": "0.28.13",
       "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.28.13.tgz",
       "integrity": "sha512-PDpL8W/kbyeWi0mQ2OruyqE8ZUAdxPs1xCbDX3WXJwy2oU+X2UTbkuweJHVpS9CIqmZulBoWQAmlf6t6zr1N/g==",
       "dependencies": {
         "bn.js": "^5.2.0"
       }
+    },
+    "node_modules/@cosmjs/crypto": {
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.31.3.tgz",
+      "integrity": "sha512-vRbvM9ZKR2017TO73dtJ50KxoGcFzKtKI7C8iO302BQ5p+DuB+AirUg1952UpSoLfv5ki9O416MFANNg8UN/EQ==",
+      "dependencies": {
+        "@cosmjs/encoding": "^0.31.3",
+        "@cosmjs/math": "^0.31.3",
+        "@cosmjs/utils": "^0.31.3",
+        "@noble/hashes": "^1",
+        "bn.js": "^5.2.0",
+        "elliptic": "^6.5.4",
+        "libsodium-wrappers-sumo": "^0.7.11"
+      }
+    },
+    "node_modules/@cosmjs/crypto/node_modules/@cosmjs/encoding": {
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.31.3.tgz",
+      "integrity": "sha512-6IRtG0fiVYwyP7n+8e54uTx2pLYijO48V3t9TLiROERm5aUAIzIlz6Wp0NYaI5he9nh1lcEGJ1lkquVKFw3sUg==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "bech32": "^1.1.4",
+        "readonly-date": "^1.0.0"
+      }
+    },
+    "node_modules/@cosmjs/crypto/node_modules/@cosmjs/math": {
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.31.3.tgz",
+      "integrity": "sha512-kZ2C6glA5HDb9hLz1WrftAjqdTBb3fWQsRR+Us2HsjAYdeE6M3VdXMsYCP5M3yiihal1WDwAY2U7HmfJw7Uh4A==",
+      "dependencies": {
+        "bn.js": "^5.2.0"
+      }
+    },
+    "node_modules/@cosmjs/crypto/node_modules/@cosmjs/utils": {
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.31.3.tgz",
+      "integrity": "sha512-VBhAgzrrYdIe0O5IbKRqwszbQa7ZyQLx9nEQuHQ3HUplQW7P44COG/ye2n6AzCudtqxmwdX7nyX8ta1J07GoqA=="
     },
     "node_modules/@cosmjs/encoding": {
       "version": "0.28.13",
@@ -823,6 +867,20 @@
         "long": "^4.0.0"
       }
     },
+    "node_modules/@cosmjs/proto-signing/node_modules/@cosmjs/crypto": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.28.13.tgz",
+      "integrity": "sha512-ynKfM0q/tMBQMHJby6ad8lR3gkgBKaelQhIsCZTjClsnuC7oYT9y3ThSZCUWr7Pa9h0J8ahU2YV2oFWFVWJQzQ==",
+      "dependencies": {
+        "@cosmjs/encoding": "0.28.13",
+        "@cosmjs/math": "0.28.13",
+        "@cosmjs/utils": "0.28.13",
+        "@noble/hashes": "^1",
+        "bn.js": "^5.2.0",
+        "elliptic": "^6.5.3",
+        "libsodium-wrappers": "^0.7.6"
+      }
+    },
     "node_modules/@cosmjs/proto-signing/node_modules/@cosmjs/math": {
       "version": "0.28.13",
       "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.28.13.tgz",
@@ -892,6 +950,20 @@
         "axios": "^0.21.2",
         "readonly-date": "^1.0.0",
         "xstream": "^11.14.0"
+      }
+    },
+    "node_modules/@cosmjs/tendermint-rpc/node_modules/@cosmjs/crypto": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.28.13.tgz",
+      "integrity": "sha512-ynKfM0q/tMBQMHJby6ad8lR3gkgBKaelQhIsCZTjClsnuC7oYT9y3ThSZCUWr7Pa9h0J8ahU2YV2oFWFVWJQzQ==",
+      "dependencies": {
+        "@cosmjs/encoding": "0.28.13",
+        "@cosmjs/math": "0.28.13",
+        "@cosmjs/utils": "0.28.13",
+        "@noble/hashes": "^1",
+        "bn.js": "^5.2.0",
+        "elliptic": "^6.5.3",
+        "libsodium-wrappers": "^0.7.6"
       }
     },
     "node_modules/@cosmjs/tendermint-rpc/node_modules/@cosmjs/math": {
@@ -2166,6 +2238,28 @@
         "@babel/plugin-transform-react-jsx": "7.19.0"
       }
     },
+    "node_modules/@terran-one/cosmwasm-vm-js/node_modules/@cosmjs/crypto": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.28.13.tgz",
+      "integrity": "sha512-ynKfM0q/tMBQMHJby6ad8lR3gkgBKaelQhIsCZTjClsnuC7oYT9y3ThSZCUWr7Pa9h0J8ahU2YV2oFWFVWJQzQ==",
+      "dependencies": {
+        "@cosmjs/encoding": "0.28.13",
+        "@cosmjs/math": "0.28.13",
+        "@cosmjs/utils": "0.28.13",
+        "@noble/hashes": "^1",
+        "bn.js": "^5.2.0",
+        "elliptic": "^6.5.3",
+        "libsodium-wrappers": "^0.7.6"
+      }
+    },
+    "node_modules/@terran-one/cosmwasm-vm-js/node_modules/@cosmjs/math": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.28.13.tgz",
+      "integrity": "sha512-PDpL8W/kbyeWi0mQ2OruyqE8ZUAdxPs1xCbDX3WXJwy2oU+X2UTbkuweJHVpS9CIqmZulBoWQAmlf6t6zr1N/g==",
+      "dependencies": {
+        "bn.js": "^5.2.0"
+      }
+    },
     "node_modules/@terran-one/cosmwasm-vm-js/node_modules/bech32": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
@@ -2190,6 +2284,28 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@terran-one/cw-simulate/node_modules/@cosmjs/crypto": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.28.13.tgz",
+      "integrity": "sha512-ynKfM0q/tMBQMHJby6ad8lR3gkgBKaelQhIsCZTjClsnuC7oYT9y3ThSZCUWr7Pa9h0J8ahU2YV2oFWFVWJQzQ==",
+      "dependencies": {
+        "@cosmjs/encoding": "0.28.13",
+        "@cosmjs/math": "0.28.13",
+        "@cosmjs/utils": "0.28.13",
+        "@noble/hashes": "^1",
+        "bn.js": "^5.2.0",
+        "elliptic": "^6.5.3",
+        "libsodium-wrappers": "^0.7.6"
+      }
+    },
+    "node_modules/@terran-one/cw-simulate/node_modules/@cosmjs/math": {
+      "version": "0.28.13",
+      "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.28.13.tgz",
+      "integrity": "sha512-PDpL8W/kbyeWi0mQ2OruyqE8ZUAdxPs1xCbDX3WXJwy2oU+X2UTbkuweJHVpS9CIqmZulBoWQAmlf6t6zr1N/g==",
+      "dependencies": {
+        "bn.js": "^5.2.0"
       }
     },
     "node_modules/@terran-one/cw-simulate/node_modules/tslib": {
@@ -5083,12 +5199,25 @@
       "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.10.tgz",
       "integrity": "sha512-eY+z7hDrDKxkAK+QKZVNv92A5KYkxfvIshtBJkmg5TSiCnYqZP3i9OO9whE79Pwgm4jGaoHgkM4ao/b9Cyu4zQ=="
     },
+    "node_modules/libsodium-sumo": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.7.13.tgz",
+      "integrity": "sha512-zTGdLu4b9zSNLfovImpBCbdAA4xkpkZbMnSQjP8HShyOutnGjRHmSOKlsylh1okao6QhLiz7nG98EGn+04cZjQ=="
+    },
     "node_modules/libsodium-wrappers": {
       "version": "0.7.10",
       "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.10.tgz",
       "integrity": "sha512-pO3F1Q9NPLB/MWIhehim42b/Fwb30JNScCNh8TcQ/kIc+qGLQch8ag8wb0keK3EP5kbGakk1H8Wwo7v+36rNQg==",
       "dependencies": {
         "libsodium": "^0.7.0"
+      }
+    },
+    "node_modules/libsodium-wrappers-sumo": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.13.tgz",
+      "integrity": "sha512-lz4YdplzDRh6AhnLGF2Dj2IUj94xRN6Bh8T0HLNwzYGwPehQJX6c7iYVrFUPZ3QqxE0bqC+K0IIqqZJYWumwSQ==",
+      "dependencies": {
+        "libsodium-sumo": "^0.7.13"
       }
     },
     "node_modules/listenercount": {
@@ -7891,6 +8020,20 @@
         "@cosmjs/utils": "0.28.13"
       },
       "dependencies": {
+        "@cosmjs/crypto": {
+          "version": "0.28.13",
+          "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.28.13.tgz",
+          "integrity": "sha512-ynKfM0q/tMBQMHJby6ad8lR3gkgBKaelQhIsCZTjClsnuC7oYT9y3ThSZCUWr7Pa9h0J8ahU2YV2oFWFVWJQzQ==",
+          "requires": {
+            "@cosmjs/encoding": "0.28.13",
+            "@cosmjs/math": "0.28.13",
+            "@cosmjs/utils": "0.28.13",
+            "@noble/hashes": "^1",
+            "bn.js": "^5.2.0",
+            "elliptic": "^6.5.3",
+            "libsodium-wrappers": "^0.7.6"
+          }
+        },
         "@cosmjs/math": {
           "version": "0.28.13",
           "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.28.13.tgz",
@@ -7919,6 +8062,20 @@
         "pako": "^2.0.2"
       },
       "dependencies": {
+        "@cosmjs/crypto": {
+          "version": "0.28.13",
+          "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.28.13.tgz",
+          "integrity": "sha512-ynKfM0q/tMBQMHJby6ad8lR3gkgBKaelQhIsCZTjClsnuC7oYT9y3ThSZCUWr7Pa9h0J8ahU2YV2oFWFVWJQzQ==",
+          "requires": {
+            "@cosmjs/encoding": "0.28.13",
+            "@cosmjs/math": "0.28.13",
+            "@cosmjs/utils": "0.28.13",
+            "@noble/hashes": "^1",
+            "bn.js": "^5.2.0",
+            "elliptic": "^6.5.3",
+            "libsodium-wrappers": "^0.7.6"
+          }
+        },
         "@cosmjs/math": {
           "version": "0.28.13",
           "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.28.13.tgz",
@@ -7930,26 +8087,41 @@
       }
     },
     "@cosmjs/crypto": {
-      "version": "0.28.13",
-      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.28.13.tgz",
-      "integrity": "sha512-ynKfM0q/tMBQMHJby6ad8lR3gkgBKaelQhIsCZTjClsnuC7oYT9y3ThSZCUWr7Pa9h0J8ahU2YV2oFWFVWJQzQ==",
+      "version": "0.31.3",
+      "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.31.3.tgz",
+      "integrity": "sha512-vRbvM9ZKR2017TO73dtJ50KxoGcFzKtKI7C8iO302BQ5p+DuB+AirUg1952UpSoLfv5ki9O416MFANNg8UN/EQ==",
       "requires": {
-        "@cosmjs/encoding": "0.28.13",
-        "@cosmjs/math": "0.28.13",
-        "@cosmjs/utils": "0.28.13",
+        "@cosmjs/encoding": "^0.31.3",
+        "@cosmjs/math": "^0.31.3",
+        "@cosmjs/utils": "^0.31.3",
         "@noble/hashes": "^1",
         "bn.js": "^5.2.0",
-        "elliptic": "^6.5.3",
-        "libsodium-wrappers": "^0.7.6"
+        "elliptic": "^6.5.4",
+        "libsodium-wrappers-sumo": "^0.7.11"
       },
       "dependencies": {
+        "@cosmjs/encoding": {
+          "version": "0.31.3",
+          "resolved": "https://registry.npmjs.org/@cosmjs/encoding/-/encoding-0.31.3.tgz",
+          "integrity": "sha512-6IRtG0fiVYwyP7n+8e54uTx2pLYijO48V3t9TLiROERm5aUAIzIlz6Wp0NYaI5he9nh1lcEGJ1lkquVKFw3sUg==",
+          "requires": {
+            "base64-js": "^1.3.0",
+            "bech32": "^1.1.4",
+            "readonly-date": "^1.0.0"
+          }
+        },
         "@cosmjs/math": {
-          "version": "0.28.13",
-          "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.28.13.tgz",
-          "integrity": "sha512-PDpL8W/kbyeWi0mQ2OruyqE8ZUAdxPs1xCbDX3WXJwy2oU+X2UTbkuweJHVpS9CIqmZulBoWQAmlf6t6zr1N/g==",
+          "version": "0.31.3",
+          "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.31.3.tgz",
+          "integrity": "sha512-kZ2C6glA5HDb9hLz1WrftAjqdTBb3fWQsRR+Us2HsjAYdeE6M3VdXMsYCP5M3yiihal1WDwAY2U7HmfJw7Uh4A==",
           "requires": {
             "bn.js": "^5.2.0"
           }
+        },
+        "@cosmjs/utils": {
+          "version": "0.31.3",
+          "resolved": "https://registry.npmjs.org/@cosmjs/utils/-/utils-0.31.3.tgz",
+          "integrity": "sha512-VBhAgzrrYdIe0O5IbKRqwszbQa7ZyQLx9nEQuHQ3HUplQW7P44COG/ye2n6AzCudtqxmwdX7nyX8ta1J07GoqA=="
         }
       }
     },
@@ -8069,6 +8241,20 @@
         "long": "^4.0.0"
       },
       "dependencies": {
+        "@cosmjs/crypto": {
+          "version": "0.28.13",
+          "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.28.13.tgz",
+          "integrity": "sha512-ynKfM0q/tMBQMHJby6ad8lR3gkgBKaelQhIsCZTjClsnuC7oYT9y3ThSZCUWr7Pa9h0J8ahU2YV2oFWFVWJQzQ==",
+          "requires": {
+            "@cosmjs/encoding": "0.28.13",
+            "@cosmjs/math": "0.28.13",
+            "@cosmjs/utils": "0.28.13",
+            "@noble/hashes": "^1",
+            "bn.js": "^5.2.0",
+            "elliptic": "^6.5.3",
+            "libsodium-wrappers": "^0.7.6"
+          }
+        },
         "@cosmjs/math": {
           "version": "0.28.13",
           "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.28.13.tgz",
@@ -8144,6 +8330,20 @@
         "xstream": "^11.14.0"
       },
       "dependencies": {
+        "@cosmjs/crypto": {
+          "version": "0.28.13",
+          "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.28.13.tgz",
+          "integrity": "sha512-ynKfM0q/tMBQMHJby6ad8lR3gkgBKaelQhIsCZTjClsnuC7oYT9y3ThSZCUWr7Pa9h0J8ahU2YV2oFWFVWJQzQ==",
+          "requires": {
+            "@cosmjs/encoding": "0.28.13",
+            "@cosmjs/math": "0.28.13",
+            "@cosmjs/utils": "0.28.13",
+            "@noble/hashes": "^1",
+            "bn.js": "^5.2.0",
+            "elliptic": "^6.5.3",
+            "libsodium-wrappers": "^0.7.6"
+          }
+        },
         "@cosmjs/math": {
           "version": "0.28.13",
           "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.28.13.tgz",
@@ -8965,6 +9165,28 @@
         "util": "^0.12.4"
       },
       "dependencies": {
+        "@cosmjs/crypto": {
+          "version": "0.28.13",
+          "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.28.13.tgz",
+          "integrity": "sha512-ynKfM0q/tMBQMHJby6ad8lR3gkgBKaelQhIsCZTjClsnuC7oYT9y3ThSZCUWr7Pa9h0J8ahU2YV2oFWFVWJQzQ==",
+          "requires": {
+            "@cosmjs/encoding": "0.28.13",
+            "@cosmjs/math": "0.28.13",
+            "@cosmjs/utils": "0.28.13",
+            "@noble/hashes": "^1",
+            "bn.js": "^5.2.0",
+            "elliptic": "^6.5.3",
+            "libsodium-wrappers": "^0.7.6"
+          }
+        },
+        "@cosmjs/math": {
+          "version": "0.28.13",
+          "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.28.13.tgz",
+          "integrity": "sha512-PDpL8W/kbyeWi0mQ2OruyqE8ZUAdxPs1xCbDX3WXJwy2oU+X2UTbkuweJHVpS9CIqmZulBoWQAmlf6t6zr1N/g==",
+          "requires": {
+            "bn.js": "^5.2.0"
+          }
+        },
         "bech32": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
@@ -8990,6 +9212,28 @@
         "tslib": "^2.4.0"
       },
       "dependencies": {
+        "@cosmjs/crypto": {
+          "version": "0.28.13",
+          "resolved": "https://registry.npmjs.org/@cosmjs/crypto/-/crypto-0.28.13.tgz",
+          "integrity": "sha512-ynKfM0q/tMBQMHJby6ad8lR3gkgBKaelQhIsCZTjClsnuC7oYT9y3ThSZCUWr7Pa9h0J8ahU2YV2oFWFVWJQzQ==",
+          "requires": {
+            "@cosmjs/encoding": "0.28.13",
+            "@cosmjs/math": "0.28.13",
+            "@cosmjs/utils": "0.28.13",
+            "@noble/hashes": "^1",
+            "bn.js": "^5.2.0",
+            "elliptic": "^6.5.3",
+            "libsodium-wrappers": "^0.7.6"
+          }
+        },
+        "@cosmjs/math": {
+          "version": "0.28.13",
+          "resolved": "https://registry.npmjs.org/@cosmjs/math/-/math-0.28.13.tgz",
+          "integrity": "sha512-PDpL8W/kbyeWi0mQ2OruyqE8ZUAdxPs1xCbDX3WXJwy2oU+X2UTbkuweJHVpS9CIqmZulBoWQAmlf6t6zr1N/g==",
+          "requires": {
+            "bn.js": "^5.2.0"
+          }
+        },
         "tslib": {
           "version": "2.4.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
@@ -11173,12 +11417,25 @@
       "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.10.tgz",
       "integrity": "sha512-eY+z7hDrDKxkAK+QKZVNv92A5KYkxfvIshtBJkmg5TSiCnYqZP3i9OO9whE79Pwgm4jGaoHgkM4ao/b9Cyu4zQ=="
     },
+    "libsodium-sumo": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.7.13.tgz",
+      "integrity": "sha512-zTGdLu4b9zSNLfovImpBCbdAA4xkpkZbMnSQjP8HShyOutnGjRHmSOKlsylh1okao6QhLiz7nG98EGn+04cZjQ=="
+    },
     "libsodium-wrappers": {
       "version": "0.7.10",
       "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.10.tgz",
       "integrity": "sha512-pO3F1Q9NPLB/MWIhehim42b/Fwb30JNScCNh8TcQ/kIc+qGLQch8ag8wb0keK3EP5kbGakk1H8Wwo7v+36rNQg==",
       "requires": {
         "libsodium": "^0.7.0"
+      }
+    },
+    "libsodium-wrappers-sumo": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.13.tgz",
+      "integrity": "sha512-lz4YdplzDRh6AhnLGF2Dj2IUj94xRN6Bh8T0HLNwzYGwPehQJX6c7iYVrFUPZ3QqxE0bqC+K0IIqqZJYWumwSQ==",
+      "requires": {
+        "libsodium-sumo": "^0.7.13"
       }
     },
     "listenercount": {

--- a/package.json
+++ b/package.json
@@ -315,6 +315,11 @@
                     "%cosmywasmy.chains.items.signType.ethsecp256k1.desc%"
                   ]
                 },
+                "coinType": {
+                  "type": "string",
+                  "default": "118", 
+                  "description": "%cosmywasmy.chains.items.coinType.desc%"
+                },
                 "chainDenom": {
                   "type": "string",
                   "description": "%cosmywasmy.chains.items.chainDenom.desc%"
@@ -483,6 +488,7 @@
                 "rpcEndpoint": "http://localhost:26657",
                 "defaultGasPrice": "0.015",
                 "chainDenom": "cony",
+                "coinType": "438",
                 "faucetEndpoint": "http://localhost:8081"
               },
               {
@@ -493,6 +499,7 @@
                 "rpcEndpoint": "https://ebony-rpc.finschia.io/",
                 "defaultGasPrice": "0.015",
                 "chainDenom": "tcony",
+                "coinType": "438",
                 "accountExplorerLink": "https://explorer.blockchain.line.me/ebony/address/${accountAddress}",
                 "txExplorerLink": "https://explorer.blockchain.line.me/ebony/transaction/${txHash}",
                 "faucetEndpoint": "https://faucet-ebonynw.line-apps.com"
@@ -1237,6 +1244,7 @@
     "@cosmjs/launchpad": "^0.27.1",
     "@cosmjs/math": "^0.30.1",
     "@cosmjs/proto-signing": "^0.28.4",
+    "@cosmjs/crypto": "^0.31.0",
     "@terran-one/cw-simulate": "^2.8.0",
     "@vscode/l10n": "^0.0.10",
     "@vscode/l10n-dev": "^0.0.24",

--- a/package.nls.json
+++ b/package.nls.json
@@ -52,6 +52,7 @@
     "cosmywasmy.chains.items.signType.desc": "The signature algorithm when signing transactions, `ethsecp256k1` or `tmsecp256k1`, default `tmsecp256k1`",
     "cosmywasmy.chains.items.signType.tmsecp256k1.desc": "Used for Cosmos/Tendermint chains signing",
     "cosmywasmy.chains.items.signType.ethsecp256k1.desc": "Used for Ethereum/EVM chains signing",
+    "cosmywasmy.chains.items.coinType.desc": "Used for distinguishing between different cryptocurrencies in hierarchical deterministic wallets, default `118`",
     "cosmywasmy.chains.items.faucetEndpoint.desc": "Faucet address and port to request funds",
     "cosmywasmy.chains.items.accountExplorerLink.desc": "Block explorer url which includes '${accountAddress}' text to generate account url",
     "cosmywasmy.chains.items.txExplorerLink.desc": "Block explorer url which includes '${txHash}' text to generate tx url",

--- a/src/helpers/Cosmwasm/API.ts
+++ b/src/helpers/Cosmwasm/API.ts
@@ -68,7 +68,7 @@ export class Cosmwasm {
 
     public static async GetSigningClient(): Promise<SigningCosmWasmClient> {
         const account = Workspace.GetSelectedAccount();
-        let signer = await WrapWallet.fromMnemonic(global.workspaceChain.signType, account.mnemonic, {
+        let signer = await WrapWallet.fromMnemonic(global.workspaceChain.signType, global.workspaceChain.coinType, account.mnemonic, {
             prefix: global.workspaceChain.addressPrefix,
         });
         let gasDenom = global.workspaceChain.chainGasDenom;

--- a/src/helpers/Cosmwasm/SmartExecutor.ts
+++ b/src/helpers/Cosmwasm/SmartExecutor.ts
@@ -11,7 +11,7 @@ export class SmartExecutor {
     private client: SigningCosmWasmClient;
 
     public async SetupAccount(mnemonic: string, addressPrefix: string) {
-        this.wallet = await WrapWallet.fromMnemonic(global.workspaceChain.signType, mnemonic, {
+        this.wallet = await WrapWallet.fromMnemonic(global.workspaceChain.signType, global.workspaceChain.coinType, mnemonic, {
             prefix: addressPrefix,
         });
         const accounts = await this.wallet.getAccounts();

--- a/src/helpers/Workspace.ts
+++ b/src/helpers/Workspace.ts
@@ -136,6 +136,7 @@ export class ChainConfig {
     chainGasDenom!: string;
     chainDenomDecimals!: string;
     signType!: string;
+    coinType!: string;
 
     public Validate() {
         if (!this) {

--- a/src/models/Account.ts
+++ b/src/models/Account.ts
@@ -23,7 +23,7 @@ export class Account extends vscode.TreeItem {
 	public static async GetAccounts(context: vscode.Memento): Promise<Account[]> {
 		const accountData = this.GetAccountsBasic(context);
 		for (let account of accountData) {
-			const wallet = await WrapWallet.fromMnemonic(global.workspaceChain.signType, account.mnemonic, {
+			const wallet = await WrapWallet.fromMnemonic(global.workspaceChain.signType, global.workspaceChain.coinType, account.mnemonic, {
 				prefix: global.workspaceChain.addressPrefix
 			});
 			const accounts = await wallet.getAccounts();
@@ -45,7 +45,7 @@ export class Account extends vscode.TreeItem {
 	public static async AddAccount(context: vscode.Memento, account: Account) {
 		try{
 			//fix import error mnemonic,  failed to load account when restart vscode
-			await (await WrapWallet.fromMnemonic(global.workspaceChain.signType, account.mnemonic, {
+			await (await WrapWallet.fromMnemonic(global.workspaceChain.signType, global.workspaceChain.coinType, account.mnemonic, {
 				prefix: global.workspaceChain.addressPrefix
 			})).getAccounts();
 	

--- a/src/views/SignProvider.ts
+++ b/src/views/SignProvider.ts
@@ -36,7 +36,7 @@ export class SignProvider implements vscode.WebviewViewProvider {
 			return;
 		}
 		try {
-			let wallet = await WrapWallet.fromMnemonic(global.workspaceChain.signType, account.mnemonic, {
+			let wallet = await WrapWallet.fromMnemonic(global.workspaceChain.signType, global.workspaceChain.coinType, account.mnemonic, {
 				prefix: global.workspaceChain.addressPrefix,
 			});
 			const signDoc = this.makeSignDoc(account.address, data.value);


### PR DESCRIPTION
This PR enables to support non-118 cointype.
118 is set as the default value, so there is no need to change the old settings.

close: #82