### PR TITLE
fix: fix default chain name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ All notable changes to the Cosmy Wasmy extension will be documented in this file
 
 ### Fixed
 
-- Fix default configuration
+- Fix default chain name
 
 ### Security 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ All notable changes to the Cosmy Wasmy extension will be documented in this file
 
 ### Fixed
 
+- Fix default configuration
+
 ### Security 
 
 

--- a/package.json
+++ b/package.json
@@ -245,7 +245,7 @@
             "markdownDescription": "%cosmywasmy.chainConfigName.desc%",
             "scope": "resource",
             "order": 0,
-            "default": "Juno UNI-5 testnet",
+            "default": "Juno uni-6",
             "deprecationMessage": "%cosmywasmy.chainConfigName.deprecationDesc%"
           },
           "cosmywasmy.chains": {


### PR DESCRIPTION
When first time approach, the following error will occur.

> Currently selected chain is 'Juno UNI-5 testnet' but no chain config with that name was found in the configured chains. Selecting fallback chain 'Juno uni-6'


This PR fixes this.