### PR TITLE
fix: fix auto complete for latest cosmwasm-schema version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ All notable changes to the Cosmy Wasmy extension will be documented in this file
 
 ### Fixed
 
+- Fix auto complete for latest cosmwasm version
+
 ### Security 
 
 

--- a/src/commands/terminal.ts
+++ b/src/commands/terminal.ts
@@ -60,6 +60,26 @@ export class TerminalCmds {
 					"*.json"
 				],
 				url: "/schema/migrate_msg.json"
+			}, {
+				fileMatch: [
+					"*.json"
+				],
+				url: "/schema/raw/execute.json"
+			}, {
+				fileMatch: [
+					"*.json"
+				],
+				url: "/schema/raw/query.json"
+			}, {
+				fileMatch: [
+					"*.json"
+				],
+				url: "/schema/raw/instantiate.json"
+			}, {
+				fileMatch: [
+					"*.json"
+				],
+				url: "/schema/raw/migrate.json"
 			}];
 			Workspace.SetWorkspaceSchemaAutoComplete(schema);
 		});


### PR DESCRIPTION
Output structure generated by latest cosmwasm-schema is different from old one so auto-complete doesn't work.

This PR fixes this.